### PR TITLE
bugfix/lock_click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ packages = [{include = "repair_alloy_spec"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 langroid = "0.1.244"
+click = "<8.2.0"
 
 
 [build-system]


### PR DESCRIPTION
Lock click so cli will work, similar issue - https://github.com/ai-dynamo/dynamo/issues/1039

Another way to make sure that the versions won't break is to commit the lock file but I see that it's in gitignore