### PR TITLE
Exp/exclude oracle block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ packages = [{include = "repair_alloy_spec"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 langroid = "0.1.244"
+click = "<8.2.0"
 
 
 [build-system]

--- a/repair_alloy_spec/alloy_verification_tool.py
+++ b/repair_alloy_spec/alloy_verification_tool.py
@@ -20,7 +20,6 @@ from langroid.mytypes import Entity
 from langroid.agent.chat_agent import ChatAgent, ChatAgentConfig
 from langroid.agent.tool_message import ToolMessage
 from langroid.agent.chat_document import ChatDocument
-from langroid.language_models.azure_openai import AzureConfig
 
 
 class VerifierMessage(ToolMessage):
@@ -77,6 +76,7 @@ class AlloyAnalzerAgent(ChatAgent):
     analyzer_agent_tokens: int = 0
     analyzer_agent_cost: float = 0.0
     start_time: float = 0.0
+    oracle_block: str | None = None
 
     sys_instructions = (
         "You are an expert in repairing Alloy declarative specifications.\n"
@@ -302,7 +302,12 @@ class AlloyAnalzerAgent(ChatAgent):
             proposed_spec_file = proposed_spec_file_no_ext + ".als"
 
             with open(proposed_spec_file, "w") as f:
-                f.write(self.proposed_spec)
+                content_to_write = self.proposed_spec
+                if self.oracle_block:
+                    content_to_write = (
+                        content_to_write.rstrip() + "\n\n" + self.oracle_block.lstrip()
+                    )
+                f.write(content_to_write)
 
             command = [
                 "java",

--- a/repair_alloy_spec/alloy_verification_tool.py
+++ b/repair_alloy_spec/alloy_verification_tool.py
@@ -234,11 +234,6 @@ class AlloyAnalzerAgent(ChatAgent):
                 elif (
                     self.opts.feedback == FeedbackOption.AUTO_FEEDBACK
                 ):
-                    # llm_config = AzureConfig(
-                    #     timeout=50, stream=True, temperature=0.2, max_output_tokens=3000
-                    # )
-                    # llm_config = self.llm
-
                     prompt_agent_cfg = ChatAgentConfig(llm=self.config.llm)
                     prompt_agent = ChatAgent(prompt_agent_cfg)
                     response = prompt_agent.llm_response(

--- a/repair_alloy_spec/repair_chat.py
+++ b/repair_alloy_spec/repair_chat.py
@@ -25,7 +25,6 @@ from langroid.agent.task import Task
 from langroid.utils.configuration import Settings, set_global
 from langroid.utils.logging import setup_colored_logging
 from alloy_verification_tool import AlloyAnalzerAgent, VerifierMessage
-from langroid.language_models.openai_gpt import OpenAIChatModel
 
 app = typer.Typer()
 setup_colored_logging()
@@ -111,7 +110,15 @@ def chat(opts: CLIOptions) -> None:
             try:
                 with open(spec_file, "r") as file:
                     spec = file.read()
-                    lines = spec.splitlines()
+                    oracle_marker = "/*======== IFF PERFECT ORACLE ===============*/"
+                    oracle_block = ""
+                    if oracle_marker in spec:
+                        pre, post = spec.split(oracle_marker, 1)
+                        oracle_block = oracle_marker + post
+                        spec_core = pre
+                    else:
+                        spec_core = spec
+                    lines = spec_core.splitlines()
                     cleaned_lines = [line.replace("\t", "").strip() for line in lines]
                     cleaned_spec = "\n".join(cleaned_lines)
 
@@ -134,6 +141,8 @@ def chat(opts: CLIOptions) -> None:
                     os.path.basename(agent.orig_spec_file)
                 )[0]
                 agent.opts = opts
+                # Store oracle section (if present) for re-attachment later
+                agent.oracle_block = oracle_block
                 agent.start_time = time.time()
                 task = Task(
                     agent,


### PR DESCRIPTION
Currently there is a problem that the LLM sees both the question and the solution (Under the oracle marker).

I tried to solve it in the a4f dataset in a way that hides the oracle from the LLM and reattach it later.
If I understand correctly, it's important to evaluate again the results of a4f with these changes